### PR TITLE
Add blockTimeout as a configurable param

### DIFF
--- a/metrics/types/prometheus.go
+++ b/metrics/types/prometheus.go
@@ -10,10 +10,10 @@ import (
 )
 
 type ChainMetrics struct {
-	BlocksProcessed prometheus.Counter
+	BlocksProcessed      prometheus.Counter
 	LatestProcessedBlock prometheus.Gauge
-	LatestKnownBlock prometheus.Gauge
-	VotesSubmitted  prometheus.Counter
+	LatestKnownBlock     prometheus.Gauge
+	VotesSubmitted       prometheus.Counter
 }
 
 func NewChainMetrics(chain string) *ChainMetrics {


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Description

Makes the timeout value for changes in block height configurable.

## Changes

- Rename `timeDelay` to `blockTimeOut`
- Pass `blockTimeout` into health server constructor

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #?
